### PR TITLE
Lets plugin work with minted package

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -66,7 +66,7 @@ function! s:Compile()
     silent exec 'write! ' . b:livepreview_buf_data['tmp_src_file']
 
     call s:RunInBackground(
-                \ 'pdflatex -interaction=nonstopmode -output-directory=' .
+                \ 'pdflatex -shell-escape -interaction=nonstopmode -output-directory=' .
                 \ b:livepreview_buf_data['tmp_dir'] . ' ' .
                 \ b:livepreview_buf_data['tmp_src_file'])
 
@@ -99,7 +99,7 @@ EEOOFF
     let l:tmp_out_file = b:livepreview_buf_data['tmp_dir'] . '/' .
                 \ expand('%:r') . '.pdf'
 
-    silent call system('pdflatex -interaction=nonstopmode -output-directory=' .
+    silent call system('pdflatex -shell-escape -interaction=nonstopmode -output-directory=' .
                 \ b:livepreview_buf_data['tmp_dir'] . ' ' .
                 \ b:livepreview_buf_data['tmp_src_file'])
     if v:shell_error != 0
@@ -121,7 +121,7 @@ EEOOFF
                     \ ' && bibtex *.aux')
         " Bibtex requires multiple latex compilations:
         silent call system(
-                    \ 'pdflatex -interaction=nonstopmode -output-directory=' .
+                    \ 'pdflatex -shell-escape -interaction=nonstopmode -output-directory=' .
                     \ b:livepreview_buf_data['tmp_dir'] . ' ' .
                     \ b:livepreview_buf_data['tmp_src_file'])
     endif


### PR DESCRIPTION
Just a quick one, trying to use live preview with a document containing minted listings doesn't work because the package needs -shell-escape on the invocation so it can call out to Pygments for the syntax highlighting.

I've just added the switch in the relevant places.

Thanks