### PR TITLE
Exiting StartPreview() on compilation failure

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -104,6 +104,7 @@ EEOOFF
                 \ b:livepreview_buf_data['tmp_src_file'])
     if v:shell_error != 0
         echo 'Failed to compile'
+        return
     endif
 
     " Enable compilation of bibliography:
@@ -127,6 +128,7 @@ EEOOFF
     endif
     if v:shell_error != 0
         echo 'Failed to compile bibliography'
+        return
     endif
 
     call s:RunInBackground(s:previewer . ' ' . l:tmp_out_file)


### PR DESCRIPTION
Citing @dylan-chong in #21 :
>Also, a new window of Evince is still opened when the compilation fails, which is a little annoying since you have to close them one-by-one.

This commit aims to solve this issue by preventing further run as soon as a compilation error is detected.