### PR TITLE
Multiple tex files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@ try to set 'updatetime' to a higher value to make it update less frequently. The
 suggested value of 'updatetime' is `1000`.
 
 If the root file is not the file you are currently editing, you can specify it
-by executing `:LLPStartPreview <root-filename>`. The path to the root file can
-be an absolute path or a relative path, in which case it is **relative to the
-parent directory of the current file**.
+by executing `:LLPStartPreview <root-filename>` or executing `:LLPStartPreview`
+with the following declaration in the first line of your source file:
+
+```latex
+% !TEX root = <root-filename>
+```
+
+The path to the root file can be an absolute path or a relative path, in which
+case it is **relative to the parent directory of the current file**.
 
 ## Limitation
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Vim and you should see the live update. The updating time could be set by Vim's
 try to set 'updatetime' to a higher value to make it update less frequently. The
 suggested value of 'updatetime' is `1000`.
 
+If the root file is not the file you are currently editing, you can specify it
+by executing `:LLPStartPreview <root-filename>`. The path to the root file can
+be an absolute path or a relative path, in which case it is **relative to the
+parent directory of the current file**.
+
+## Limitation
+
+Currently, all files must be in the same directory.
+
 ## Screenshot
 
 ![Screenshot with Evince](https://github.com/xuhdev/vim-latex-live-preview/raw/master/screenshots/screenshot-evince.gif)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ case it is **relative to the parent directory of the current file**.
 
 ## Limitation
 
-Currently, all files must be in the same directory.
+Currently, root file must be in the same directory or upper in the project tree
+(otherwise, one has to save file to update the preview).
 
 ## Screenshot
 

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -119,7 +119,7 @@ EEOOFF
     endif
 
     " Enable compilation of bibliography:
-    let l:bib_files = split( glob( expand( '%:h' ) . '/**/*bib' ) )
+    let l:bib_files = split( glob( expand( '%:h' ) . '/**/*.bib' ) )
     if len( l:bib_files ) > 0
         for bib_file in l:bib_files
             let bib_fn = fnamemodify(bib_file, ':t')

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -94,9 +94,9 @@ EEOOFF
     let l:root_line = substitute(getline(1),
                 \ '\v^\s*\%\s*!tex\s*root\s*\=\s*(.*)\s*$',
                 \ '\1', '')
-    if ( a:0 > 0 )
+    if (a:0 > 0)
         let l:root_file = fnameescape(fnamemodify(a:1, ':p'))
-    elseif ( l:root_line != getline(1) && strlen(l:root_line) > 0 )                     " TODO: existence of `% !TEX` declaration condition must be clean...
+    elseif (l:root_line != getline(1) && strlen(l:root_line) > 0)                       " TODO: existence of `% !TEX` declaration condition must be clean...
         let l:root_file = fnameescape(fnamemodify(l:root_line, ':p'))
     else
         let l:root_file = b:livepreview_buf_data['tmp_src_file']
@@ -106,26 +106,25 @@ EEOOFF
     " Build tree for tmp_src_file (copy of the current buffer)
     let l:tmp_src_dir = fnameescape(
                 \ fnamemodify(b:livepreview_buf_data['tmp_src_file'], ':p:h'))
-    if ( !isdirectory(l:tmp_src_dir) )
+    if (!isdirectory(l:tmp_src_dir))
         silent call mkdir(l:tmp_src_dir, 'p')
     endif
     " Build tree for root_file (main tex file, which might be tmp_src_file,
     " ie. the current file)
-    if ( l:root_file == b:livepreview_buf_data['tmp_src_file'] )                        " if root file is the current file
+    if (l:root_file == b:livepreview_buf_data['tmp_src_file'])                          " if root file is the current file
         let l:tmp_root_dir = l:tmp_src_dir
     else
-         let l:tmp_root_dir = fnameescape(
-                     \ b:livepreview_buf_data['tmp_dir'] .
-                     \ fnamemodify(l:root_file, ':p:h'))
-         if ( !isdirectory(l:tmp_root_dir) )
-             silent call mkdir(l:tmp_root_dir, 'p')
-         endif
-     endif
-
+        let l:tmp_root_dir = fnameescape(
+                    \ b:livepreview_buf_data['tmp_dir'] .
+                    \ fnamemodify(l:root_file, ':p:h'))
+        if (!isdirectory(l:tmp_root_dir))
+            silent call mkdir(l:tmp_root_dir, 'p')
+        endif
+    endif
 
     " Change directory to handle properly sourced files with \input and bib
     " TODO: get rid of lcd
-    if ( l:root_file == b:livepreview_buf_data['tmp_src_file'] )                        " if root file is the current file
+    if (l:root_file == b:livepreview_buf_data['tmp_src_file'])                          " if root file is the current file
         let b:livepreview_buf_data['root_dir'] = fnameescape(expand('%:p:h'))
     else
         let b:livepreview_buf_data['root_dir'] = fnameescape(
@@ -158,12 +157,12 @@ EEOOFF
     endif
 
     " Enable compilation of bibliography:
-    let l:bib_files = split( glob( expand( '%:h' ) . '/**/*.bib' ) )                    " TODO: fails if unused bibfiles
-    if len( l:bib_files ) > 0
+    let l:bib_files = split(glob(expand('%:h') . '/**/*.bib'))                          " TODO: fails if unused bibfiles
+    if len(l:bib_files) > 0
         for bib_file in l:bib_files
             let bib_fn = fnamemodify(bib_file, ':t')
             call writefile(readfile(bib_file),
-                        \ l:tmp_root_dir . '/' . bib_fn )                               " TODO: may fail if same bibfile names in different dirs
+                        \ l:tmp_root_dir . '/' . bib_fn)                                " TODO: may fail if same bibfile names in different dirs
         endfor
 
         " Update compile command with bibliography

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -95,61 +95,61 @@ EEOOFF
                 \ '\v^\s*\%\s*!tex\s*root\s*\=\s*(.*)\s*$',
                 \ '\1', '')
     if ( a:0 > 0 )
-        let b:livepreview_buf_data['root_file'] = fnameescape(fnamemodify(a:1, ':p'))
-    elseif ( l:root_line != getline(1) && strlen(l:root_line) > 0 )                             " TODO: existence of `% !TEX` declaration condition must be clean...
-        let b:livepreview_buf_data['root_file'] = fnameescape(fnamemodify(l:root_line, ':p'))
+        let l:root_file = fnameescape(fnamemodify(a:1, ':p'))
+    elseif ( l:root_line != getline(1) && strlen(l:root_line) > 0 )                     " TODO: existence of `% !TEX` declaration condition must be clean...
+        let l:root_file = fnameescape(fnamemodify(l:root_line, ':p'))
     else
-        let b:livepreview_buf_data['root_file'] = b:livepreview_buf_data['tmp_src_file']
+        let l:root_file = b:livepreview_buf_data['tmp_src_file']
     endif
 
     " Hack for complex project trees: recreate the tree in tmp_dir
     " Build tree for tmp_src_file (copy of the current buffer)
-    let b:livepreview_buf_data['tmp_src_dir'] = fnameescape(
+    let l:tmp_src_dir = fnameescape(
                 \ fnamemodify(b:livepreview_buf_data['tmp_src_file'], ':p:h'))
-    if ( !isdirectory(b:livepreview_buf_data['tmp_src_dir']) )
-        silent call mkdir(b:livepreview_buf_data['tmp_src_dir'], 'p')
+    if ( !isdirectory(l:tmp_src_dir) )
+        silent call mkdir(l:tmp_src_dir, 'p')
     endif
     " Build tree for root_file (main tex file, which might be tmp_src_file,
     " ie. the current file)
-    if ( b:livepreview_buf_data['root_file'] == b:livepreview_buf_data['tmp_src_file'] )        " if root file is the current file
-        let b:livepreview_buf_data['tmp_root_dir'] = b:livepreview_buf_data['tmp_src_dir']
+    if ( l:root_file == b:livepreview_buf_data['tmp_src_file'] )                        " if root file is the current file
+        let l:tmp_root_dir = l:tmp_src_dir
     else
-         let b:livepreview_buf_data['tmp_root_dir'] = fnameescape(
+         let l:tmp_root_dir = fnameescape(
                      \ b:livepreview_buf_data['tmp_dir'] .
-                     \ fnamemodify(b:livepreview_buf_data['root_file'], ':p:h'))
-         if ( !isdirectory(b:livepreview_buf_data['tmp_root_dir']) )
-             silent call mkdir(b:livepreview_buf_data['tmp_root_dir'], 'p')
+                     \ fnamemodify(l:root_file, ':p:h'))
+         if ( !isdirectory(l:tmp_root_dir) )
+             silent call mkdir(l:tmp_root_dir, 'p')
          endif
      endif
 
 
     " Change directory to handle properly sourced files with \input and bib
     " TODO: get rid of lcd
-    if ( b:livepreview_buf_data['root_file'] == b:livepreview_buf_data['tmp_src_file'] )        " if root file is the current file
+    if ( l:root_file == b:livepreview_buf_data['tmp_src_file'] )                        " if root file is the current file
         let b:livepreview_buf_data['root_dir'] = fnameescape(expand('%:p:h'))
     else
         let b:livepreview_buf_data['root_dir'] = fnameescape(
-                \ fnamemodify(b:livepreview_buf_data['root_file'], ':p:h'))
+                \ fnamemodify(l:root_file, ':p:h'))
     endif
     execute 'lcd ' . b:livepreview_buf_data['root_dir']
 
     " Write the current buffer in a temporary file
     silent exec 'write! ' . b:livepreview_buf_data['tmp_src_file']
 
-    let l:tmp_out_file = b:livepreview_buf_data['tmp_root_dir'] . '/' .
-                \ fnameescape(fnamemodify(b:livepreview_buf_data['root_file'], ':t:r') . '.pdf')
+    let l:tmp_out_file = l:tmp_root_dir . '/' .
+                \ fnameescape(fnamemodify(l:root_file, ':t:r') . '.pdf')
 
     let b:livepreview_buf_data['run_cmd'] =
                 \ 'env ' .
-                \       'TEXMFOUTPUT=' . b:livepreview_buf_data['tmp_root_dir'] . ' ' .
-                \       'TEXINPUTS=' . b:livepreview_buf_data['tmp_root_dir']
+                \       'TEXMFOUTPUT=' . l:tmp_root_dir . ' ' .
+                \       'TEXINPUTS=' . l:tmp_root_dir
                 \                    . ':' . b:livepreview_buf_data['root_dir']
                 \                    . ': ' .
                 \ 'pdflatex ' .
                 \       '-shell-escape ' .
                 \       '-interaction=nonstopmode ' .
-                \       '-output-directory=' . b:livepreview_buf_data['tmp_root_dir'] . ' ' .
-                \       b:livepreview_buf_data['root_file']
+                \       '-output-directory=' . l:tmp_root_dir . ' ' .
+                \       l:root_file
                 " lcd can be avoided thanks to root_dir in TEXINPUTS
 
     silent call system(b:livepreview_buf_data['run_cmd'])
@@ -158,22 +158,22 @@ EEOOFF
     endif
 
     " Enable compilation of bibliography:
-    let l:bib_files = split( glob( expand( '%:h' ) . '/**/*.bib' ) )                            " TODO: fails if unused bibfiles
+    let l:bib_files = split( glob( expand( '%:h' ) . '/**/*.bib' ) )                    " TODO: fails if unused bibfiles
     if len( l:bib_files ) > 0
         for bib_file in l:bib_files
             let bib_fn = fnamemodify(bib_file, ':t')
             call writefile(readfile(bib_file),
-                        \ b:livepreview_buf_data['tmp_root_dir'] . '/' . bib_fn )               " TODO: may fail if same bibfile names in different dirs
+                        \ l:tmp_root_dir . '/' . bib_fn )                               " TODO: may fail if same bibfile names in different dirs
         endfor
 
         " Update compile command with bibliography
         let b:livepreview_buf_data['run_cmd'] =
                 \       'env ' .
-                \               'TEXMFOUTPUT=' . b:livepreview_buf_data['tmp_root_dir'] . ' ' .
-                \               'TEXINPUTS=' . b:livepreview_buf_data['tmp_root_dir']
+                \               'TEXMFOUTPUT=' . l:tmp_root_dir . ' ' .
+                \               'TEXINPUTS=' . l:tmp_root_dir
                 \                            . ':' . b:livepreview_buf_data['root_dir']
                 \                            . ': ' .
-                \       'bibtex ' . b:livepreview_buf_data['tmp_root_dir'] . '/*.aux' .
+                \       'bibtex ' . l:tmp_root_dir . '/*.aux' .
                 \ ' && ' .
                 \       b:livepreview_buf_data['run_cmd']
 

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -91,7 +91,7 @@ function! s:StartPreview(...)
     " Create a temp directory for current buffer
     python << EEOOFF
 vim.command("let b:livepreview_buf_data['tmp_dir'] = '" +
-        tempfile.mkdtemp() + "'")
+        tempfile.mkdtemp(prefix="vim-latex-live-preview-") + "'")
 EEOOFF
 
     let b:livepreview_buf_data['tmp_src_file'] =

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -83,7 +83,7 @@ EEOOFF
 
     let b:livepreview_buf_data['tmp_src_file'] =
                 \ b:livepreview_buf_data['tmp_dir'] . '/' .
-                \ fnameescape(expand('%:r')) . '.' . expand('%:e')
+                \ fnameescape(expand('%:r') . '.' . expand('%:e'))
 
     " Guess the root file which will be compiled, using first the argument
     " passed, then the first line declaration of the source file and
@@ -102,7 +102,7 @@ EEOOFF
     silent exec 'write! ' . b:livepreview_buf_data['tmp_src_file']
 
     let l:tmp_out_file = b:livepreview_buf_data['tmp_dir'] . '/' .
-                \ fnameescape(fnamemodify(b:livepreview_buf_data['root_file'], ':t:r')) . '.pdf'
+                \ fnameescape(fnamemodify(b:livepreview_buf_data['root_file'], ':t:r') . '.pdf')
 
     let b:livepreview_buf_data['run_cmd'] =
                 \ 'env ' .

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -98,9 +98,19 @@ EEOOFF
                 \ b:livepreview_buf_data['tmp_dir'] . '/' .
                 \ fnameescape(expand('%:r')) . '.' . expand('%:e')
 
-    let b:livepreview_buf_data['root_file'] = ( a:0 > 0 ) ?
-                \ a:1 :
-                \ b:livepreview_buf_data['tmp_src_file']
+    " Guess the root file which will be compiled, using first the argument
+    " passed, then the first line declaration of the source file and
+    " eventually fallback to the current file.
+    let l:root_line = substitute(getline(1),
+                \ '\v^\s*\%\s*!tex\s*root\s*\=\s*(.*)\s*$',
+                \ '\1', '')
+    if ( a:0 > 0 )
+        let b:livepreview_buf_data['root_file'] = a:1
+    elseif ( l:root_line != getline(1) && strlen(l:root_line) > 0 )     " TODO: existence of `% !TEX` declaration condition must be clean...
+        let b:livepreview_buf_data['root_file'] = l:root_line
+    else
+        let b:livepreview_buf_data['root_file'] = b:livepreview_buf_data['tmp_src_file']
+    endif
 
     silent exec 'write! ' . b:livepreview_buf_data['tmp_src_file']
 


### PR DESCRIPTION
This PR aims to enable live-previewing for a multi-file tex project and thus to resolve #2.
It implements @rspencer01 idea:
> In addition, if editing one of the `input`ed files, `LLStartPreview` attempts to compile the currently edited file. Perhaps an option can be set (manually by the user) to `LLStartPreview` a different filename?

There is still a bit of work to do:
- [x] support projects with multiple files in the same directory 
- [x] support complex project trees
- [x] support automation with declaration: `% !TEX root = main.tex`