### PR TITLE
Reverting local change dir when early return

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -104,6 +104,7 @@ EEOOFF
                 \ b:livepreview_buf_data['tmp_src_file'])
     if v:shell_error != 0
         echo 'Failed to compile'
+        lcd -
         return
     endif
 
@@ -128,6 +129,7 @@ EEOOFF
     endif
     if v:shell_error != 0
         echo 'Failed to compile bibliography'
+        lcd -
         return
     endif
 


### PR DESCRIPTION
I made up my mind about a previous question in #25 
I think that the user environment should not be changed by the plugin. Thus, as the current directory is changed during the script runtime, it has to be reset to its previous value at the end of the script execution, whatever is the result (succeess or failure).

I'll probably look furthermore to try to avoid using `lcd %:p:h`, but for now this patch does the job.