### PR TITLE
Refresh mupdf viewer on compile

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -207,8 +207,10 @@ EEOOFF
 
     lcd -
 
-    if s:previewer == 'mupdf'
-        let b:livepreview_buf_data['run_cmd'] .= ' && kill -s HUP $(pgrep mupdf)'
+    " When using muPDF HUP signal should be sent in order to refresh the
+    " document preview
+    if s:previewer == 'mupdf' && executable('pkill')
+        let b:livepreview_buf_data['run_cmd'] .= ' && pkill --signal HUP mupdf'
     endif
 
     let b:livepreview_buf_data['preview_running'] = 1

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -207,6 +207,10 @@ EEOOFF
 
     lcd -
 
+    if s:previewer == 'mupdf'
+        let b:livepreview_buf_data['run_cmd'] .= ' && kill -s HUP $(pgrep mupdf)'
+    endif
+
     let b:livepreview_buf_data['preview_running'] = 1
 endfunction
 


### PR DESCRIPTION
Automatically refresh mupdf viewer on compile.

Could use an optimization of saving a viewer pid and reusing it instead of `pgrep`ing.

Closes #58.
