### PR TITLE
Added POSIX-compliant updating of mupdf

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -207,6 +207,10 @@ EEOOFF
 
     lcd -
 
+    if s:previewer == 'mupdf'
+        let b:livepreviewer_buf_data['run_cmd'] .= ' && kill -s HUP $(ps a | env POSIXLY_CORRECT=1 grep -F mupdf)'
+    endif
+
     let b:livepreview_buf_data['preview_running'] = 1
 endfunction
 


### PR DESCRIPTION
This is meant to be a POSIX-compliant version of #59 since it hadn't been updated in a month.

It finds the PIDs of all mupdf processes and sends SIGHUP to them. No mupdf instance is closed, including other ones running in the background, however I am pretty sure they still recieve the SIGHUP sent.