### PR TITLE
Make use of TEXINPUTS from environment:  Fixes #106

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ overridden by setting `g:livepreview_engine` variable:
 ```vim
 let g:livepreview_engine = 'your_engine' . ' [options]'
 ```
+### TeX Inputs
+
+TeX engines use the environment variable `TEXINPUTS` to search for packages and
+input files (`\usepackage{pkg}` or `\input{filename}`). LLP passes this
+environment variable to the compiler by default.  The default can be overridden
+by setting the `g:livepreview_texinputs` variable:
+
+```vim
+let g:livepreview_engine = '/path1/to/files//:/path2/to/files//'
+```
+Note:  The double trailing `/` tells the compiler to search subdirectories.
 
 ### Bibliography executable
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ overridden by setting `g:livepreview_engine` variable:
 ```vim
 let g:livepreview_engine = 'your_engine' . ' [options]'
 ```
+
 ### TeX Inputs
 
 TeX engines use the environment variable `TEXINPUTS` to search for packages and

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ environment variable to the compiler by default.  The default can be overridden
 by setting the `g:livepreview_texinputs` variable:
 
 ```vim
-let g:livepreview_engine = '/path1/to/files//:/path2/to/files//'
+let g:livepreview_texinputs = '/path1/to/files//:/path2/to/files//'
 ```
+
 Note:  The double trailing `/` tells the compiler to search subdirectories.
 
 ### Bibliography executable

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -283,11 +283,11 @@ EEOOFF
     " Get the tex engine
     let s:engine = s:ValidateExecutables('livepreview_engine', [get(g:, 'livepreview_engine', ''), 'pdflatex', 'xelatex'])
 
-    " Initialize texinputs directory list to environment variable TEXINPUTS if g:livepreview_texinputs is not set
-    let s:static_texinputs = get(g:, 'livepreview_texinputs',$TEXINPUTS)
-
     " Get the previewer
     let s:previewer = s:ValidateExecutables('livepreview_previewer', [get(g:, 'livepreview_previewer', ''), 'evince', 'okular'])
+
+     " Initialize texinputs directory list to environment variable TEXINPUTS if g:livepreview_texinputs is not set
+    let s:static_texinputs = get(g:, 'livepreview_texinputs', $TEXINPUTS)
 
     " Select bibliography executable
     let s:use_biber = get(g:, 'livepreview_use_biber', 0)

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -283,12 +283,8 @@ EEOOFF
     " Get the tex engine
     let s:engine = s:ValidateExecutables('livepreview_engine', [get(g:, 'livepreview_engine', ''), 'pdflatex', 'xelatex'])
 
-    " Initialize livepreview_texinputs directory list to empty if not set
-    if exists('g:livepreview_texinputs')
-        let s:static_texinputs = g:livepreview_texinputs
-    else
-        let s:static_texinputs = $TEXINPUTS
-    endif
+    " Initialize texinputs directory list to environment variable TEXINPUTS if g:livepreview_texinputs is not set
+    let s:static_texinputs = get(g:, 'livepreview_texinputs',$TEXINPUTS)
 
     " Get the previewer
     let s:previewer = s:ValidateExecutables('livepreview_previewer', [get(g:, 'livepreview_previewer', ''), 'evince', 'okular'])

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -193,6 +193,7 @@ EEOOFF
                 \       'TEXMFOUTPUT=' . l:tmp_root_dir . ' ' .
                 \       'TEXINPUTS=' . l:tmp_root_dir
                 \                    . ':' . b:livepreview_buf_data['root_dir']
+                \                    . ':' . g:Tex_TEXINPUTS
                 \                    . ': ' .
                 \ s:engine . ' ' .
                 \       '-shell-escape ' .
@@ -231,6 +232,7 @@ EEOOFF
                 \               'TEXMFOUTPUT=' . l:tmp_root_dir . ' ' .
                 \               'TEXINPUTS=' . l:tmp_root_dir
                 \                            . ':' . b:livepreview_buf_data['root_dir']
+                \                            . ':' . g:Tex_TEXINPUTS
                 \                            . ': ' .
                 \ ' && ' . s:bibexec
 

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -47,11 +47,6 @@ else
     finish
 endif
 
-" prevent undefined variable error if g:Tex_TEXINPUTS not defined by user
-if !exists('g:Tex_TEXINPUTS')
-    let g:Tex_TEXINPUTS=''
-endif
-
 let s:saved_cpo = &cpo
 set cpo&vim
 
@@ -195,9 +190,9 @@ EEOOFF
     let b:livepreview_buf_data['run_cmd'] =
                 \ 'env ' .
                 \       'TEXMFOUTPUT=' . l:tmp_root_dir . ' ' .
-                \       'TEXINPUTS=' . l:tmp_root_dir
+                \       'TEXINPUTS=' . s:static_texinputs
+                \                    . ':' . l:tmp_root_dir
                 \                    . ':' . b:livepreview_buf_data['root_dir']
-                \                    . ':' . g:Tex_TEXINPUTS
                 \                    . ': ' .
                 \ s:engine . ' ' .
                 \       '-shell-escape ' .
@@ -234,9 +229,9 @@ EEOOFF
         let b:livepreview_buf_data['run_bib_cmd'] =
                 \       'env ' .
                 \               'TEXMFOUTPUT=' . l:tmp_root_dir . ' ' .
-                \               'TEXINPUTS=' . l:tmp_root_dir
+                \               'TEXINPUTS=' . s:static_texinputs
+                \                            . ':' . l:tmp_root_dir
                 \                            . ':' . b:livepreview_buf_data['root_dir']
-                \                            . ':' . g:Tex_TEXINPUTS
                 \                            . ': ' .
                 \ ' && ' . s:bibexec
 
@@ -287,6 +282,13 @@ EEOOFF
 
     " Get the tex engine
     let s:engine = s:ValidateExecutables('livepreview_engine', [get(g:, 'livepreview_engine', ''), 'pdflatex', 'xelatex'])
+
+    " Initialize livepreview_texinputs directory list to empty if not set
+    if exists('g:livepreview_texinputs')
+        let s:static_texinputs = g:livepreview_texinputs
+    else
+        let s:static_texinputs = $TEXINPUTS
+    endif
 
     " Get the previewer
     let s:previewer = s:ValidateExecutables('livepreview_previewer', [get(g:, 'livepreview_previewer', ''), 'evince', 'okular'])

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -75,6 +75,7 @@ function! s:Compile()
                 \ has_key(b:livepreview_buf_data, 'preview_running') == 0
         return
     endif
+
     " Change directory to handle properly sourced files with \input and bib
     " TODO: get rid of lcd
     execute 'lcd ' . b:livepreview_buf_data['root_dir']

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -47,6 +47,11 @@ else
     finish
 endif
 
+" prevent undefined variable error if g:Tex_TEXINPUTS not defined by user
+if !exists('g:Tex_TEXINPUTS')
+    let g:Tex_TEXINPUTS=''
+endif
+
 let s:saved_cpo = &cpo
 set cpo&vim
 
@@ -75,7 +80,6 @@ function! s:Compile()
                 \ has_key(b:livepreview_buf_data, 'preview_running') == 0
         return
     endif
-
     " Change directory to handle properly sourced files with \input and bib
     " TODO: get rid of lcd
     execute 'lcd ' . b:livepreview_buf_data['root_dir']


### PR DESCRIPTION
## Summary

I added g:Tex_TEXINPUTS to the TEXINPUTS in the run_cmd for the compiler and the bibtex compiler.

This initially failed with: `E121: Undefined variable: g:Tex_TEXINPUTS`, but that was resolved by adding
`let g:Tex_TEXINPUTS=$TEXINPUTS` to my .vimrc

To resolve this, I added defaulting of g:Tex_TEXINPUTS to '' if it was not defined.

## Other Information
This appears to be working properly now, both with and without g:Tex_TEXINPUTS being set.  If the user wants to make use of this functionality, they will have to add `let g:Tex_TEXINPUTS=$TEXINPUTS` to their .vimrc.

