### PR TITLE
Do not check that explicitly-set engine or previewer is executable

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -268,9 +268,9 @@ EEOOFF
     endif
 
     function! s:ValidateExecutables( context, executables )
-        let l:explicit_engine = get(g:, a:context, '')
-        if l:explicit_engine != ''
-            return l:explicit_engine
+        let l:user_set = get(g:, a:context, '')
+        if l:user_set != ''
+            return l:user_set
         endif
         for possible_engine in a:executables
             if executable(possible_engine)

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -268,22 +268,26 @@ EEOOFF
     endif
 
     function! s:ValidateExecutables( context, executables )
+        let l:explicit_engine = get(g:, a:context, '')
+        if l:explicit_engine != ''
+            return l:explicit_engine
+        endif
         for possible_engine in a:executables
             if executable(possible_engine)
                 return possible_engine
             endif
         endfor
         echohl ErrorMsg
-        echo printf("vim-latex-live-preview: Neither the explicitly set %s NOR the defaults are executable.", a:context)
+        echo printf("vim-latex-live-preview: The defaults for % are not executable.", a:context)
         echohl None
         throw "End execution"
     endfunction
 
     " Get the tex engine
-    let s:engine = s:ValidateExecutables('livepreview_engine', [get(g:, 'livepreview_engine', ''), 'pdflatex', 'xelatex'])
+    let s:engine = s:ValidateExecutables('livepreview_engine', ['pdflatex', 'xelatex'])
 
     " Get the previewer
-    let s:previewer = s:ValidateExecutables('livepreview_previewer', [get(g:, 'livepreview_previewer', ''), 'evince', 'okular'])
+    let s:previewer = s:ValidateExecutables('livepreview_previewer', ['evince', 'okular'])
 
     " Select bibliography executable
     let s:use_biber = get(g:, 'livepreview_use_biber', 0)


### PR DESCRIPTION
The executable check does not work for engine or preview commands that
contain arguments, like `open -a Preview`. Since the defaults are solely
executables the check can be maintained for them, but for an explicitly
set engine the user will probably have knowledge of whether the
engine/previewer can be executed anyway.

Closes #108
