### PR TITLE
Remove output on already loaded

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -22,7 +22,6 @@ endif
 
 " Check whether this script is already loaded
 if exists("g:loaded_vim_live_preview")
-    echo "Already loaded"
     finish
 endif
 let g:loaded_vim_live_preview = 1


### PR DESCRIPTION
* This removes the 'Already loaded' output that occurs when the plugin is loaded twice.
I get this error each time I start neovim b/c of a recent change to home-manager that
manages my neovim/ plugins. While the change could be reverted to remove this warning, the 
change is nice b/c it allows me to run neovim without using the neovim packaged by nixpkgs 
and still find my plugins. 

