### PR TITLE
adds syntex support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 
 ### Added
+- August, 1st 2023: synctex support 
 
 - [[`e33ee6c`](https://github.com/xuhdev/vim-latex-live-preview/commit/e33ee6c)] - Support multiple files project [#26](https://github.com/xuhdev/vim-latex-live-preview/pull/26)
 - [[`bf5259b`](https://github.com/xuhdev/vim-latex-live-preview/commit/bf5259b)] - Support bibliography [#3](https://github.com/xuhdev/vim-latex-live-preview/pull/3)

--- a/README.md
+++ b/README.md
@@ -92,29 +92,14 @@ must be escaped manually.
 Configuration
 -------------
 
-### PDF viewer
+### Option A: PDF viewer and TeX engine and Synctex support
+At the moment of writing the version of 'vim-latex-live-preview' contained in this fork is needed.
+For the setup details see my gist.
 
-By default, you need to have [evince][] or [okular][] installed as pdf viewers.
-But you can specify your own viewer by setting `g:livepreview_previewer`
-option in your `.vimrc`:
 
-```vim
-let g:livepreview_previewer = 'your_viewer'
-```
+### Option B: PDF viewer and TeX engine (without synctex)
+See [original plugin](https://github.com/xuhdev/vim-latex-live-preview)
 
-Please note that not every pdf viewer could work with this plugin. Currently
-evince and okular are known to work well. You can find a list of known working
-pdf viewers [here](https://github.com/xuhdev/vim-latex-live-preview/wiki/Known-Working-PDF-Viewers).
-
-### TeX engine
-
-`LLP` uses `pdflatex` as default engine to output a PDF to be previewed. It
-fallbacks to `xelatex` if `pdflatex` is not present. These defaults can be
-overridden by setting `g:livepreview_engine` variable:
-
-```vim
-let g:livepreview_engine = 'your_engine' . ' [options]'
-```
 
 ### TeX Inputs
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Configuration
 
 ### Option A: PDF viewer and TeX engine and Synctex support
 At the moment of writing the version of 'vim-latex-live-preview' contained in this fork is needed.
-For the setup details see my gist.
+For the setup details see [my gist](https://gist.github.com/andreas-wachtel/1025a7d2c246af267da2b84234f57d3f).
+I still intent to put a screen-cast.
 
 
 ### Option B: PDF viewer and TeX engine (without synctex)

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -88,7 +88,7 @@ function! s:Compile()
 	" BEFORE: vim did not wait for compilation.
     "call s:RunInBackground(b:livepreview_buf_data['run_cmd'])
 
-    " Now: vim waites until compilation is finished to modify the synctex file
+    " Now: vim waits until compilation is finished to modify the synctex file
     silent call system(b:livepreview_buf_data['run_cmd'])
     if v:shell_error != 0
         echo 'Failed to compile'

--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -284,7 +284,7 @@ EEOOFF
     let l:tmp_synctex = b:livepreview_buf_data['tmp_src_file'].".synctex"
 
     " The synctex.gz file is needed at both positions (where .tex is and where .pdf is)
-    silent call system("ln -fs " . l:tmp_synctex.".gz")
+    "silent call system("ln -fs " . l:tmp_synctex.".gz")
 
 
     " The following established the source file name in the synctex.gz file.


### PR DESCRIPTION
<!-- Template from https://github.com/rails/rails/blob/master/.github/pull_request_template.md -->
## Summary

My change incorporates the possibility of using forward and reverse search between vim and some pdf viewer that shows the temporarily generated pdf file.

## Other Information

At the time of writing this, your plugin does not support synctex between the temporarily generated .pdf and the source .tex file. I need a link to the .synctex.gz file and a global variable defined in the plugin in order to identify the correct pdf. 
In the README.md, I put a link to a [my gist](https://gist.github.com/andreas-wachtel/1025a7d2c246af267da2b84234f57d3f) that shows how I set up vim-latex-live-preview + zathura + synctex.
 I intent to make some screenshots, or a screencast to show that it works.

It just occurred to me, that you may not like my change of the README.md.
I also have updated the CHANGELOG.




