### PR TITLE
Fix format string in latexlivepreview.vim

### DIFF
--- a/plugin/latexlivepreview.vim
+++ b/plugin/latexlivepreview.vim
@@ -280,7 +280,7 @@ EEOOFF
             endif
         endfor
         echohl ErrorMsg
-        echo printf("vim-latex-live-preview: The defaults for % are not executable.", a:context)
+        echo printf("vim-latex-live-preview: The defaults for %s are not executable.", a:context)
         echohl None
         throw "End execution"
     endfunction


### PR DESCRIPTION
Fixed a bad call to `printf`. The formatting string does not recognize `%` as an argument and produces "Vim(echo):E767: Too many arguments to printf()".

See :
https://vimhelp.org/builtin.txt.html#printf%28%29

